### PR TITLE
Add OCLC WorldCat profile to reference data MODCPCT-13

### DIFF
--- a/src/main/java/org/folio/rest/impl/CopyCatInit.java
+++ b/src/main/java/org/folio/rest/impl/CopyCatInit.java
@@ -1,0 +1,23 @@
+package org.folio.rest.impl;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import java.util.Map;
+import org.folio.rest.jaxrs.model.TenantAttributes;
+import org.folio.rest.tools.utils.TenantLoading;
+
+public class CopyCatInit extends TenantAPI {
+
+  @Override
+  Future<Integer> loadData(TenantAttributes attributes, String tenantId,
+                           Map<String, String> headers, Context vertxContext) {
+    return super.loadData(attributes, tenantId, headers, vertxContext).compose(
+        num -> new TenantLoading()
+            .withKey("loadReference")
+            .withLead("reference-data")
+            .withPostOnly() // only install this reference data once
+            .withAcceptStatus(400) // 400 is returned if id already exists
+            .add("profiles", "copycat/profiles")
+            .perform(attributes, headers, vertxContext, num));
+  }
+}

--- a/src/main/resources/reference-data/profiles/oclc-worldcat.json
+++ b/src/main/resources/reference-data/profiles/oclc-worldcat.json
@@ -1,0 +1,7 @@
+{
+  "id" : "f26df83c-aa25-40b6-876e-96852c3d4fd4",
+  "name" : "OCLC WorldCat",
+  "url" : "zcat.oclc.org/OLUCWorldCat",
+  "externalIdQueryMap" : "@attr 1=1211 $identifier",
+  "internalIdEmbedPath" : "999ff$i"
+}

--- a/src/test/java/org/folio/rest/impl/CopycatTest.java
+++ b/src/test/java/org/folio/rest/impl/CopycatTest.java
@@ -19,6 +19,7 @@ import org.folio.rest.jaxrs.model.CopyCatImports;
 import org.folio.rest.jaxrs.model.CopyCatProfile;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.Record;
+import org.folio.rest.jaxrs.model.TenantAttributes;
 import org.folio.rest.jaxrs.resource.Copycat;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -49,12 +50,12 @@ class CopycatTest {
   }
 
   static Future<Void> tenantInit(Vertx vertx, VertxTestContext context) {
-    TenantAPI tenantAPI = new TenantAPI();
+    TenantAPI tenantAPI = new CopyCatInit();
     Map<String, String> headers = new HashMap<>();
     headers.put(XOkapiHeaders.TENANT, tenant);
     headers.put(XOkapiHeaders.URL, "http://localhost:" + mockPort);
     Promise<Void> promise = Promise.promise();
-    tenantAPI.postTenantSync(null, headers, context.succeeding(res1 -> context.verify(() -> {
+    tenantAPI.postTenantSync(new TenantAttributes(), headers, context.succeeding(res1 -> context.verify(() -> {
       assertThat(res1.getStatus()).isEqualTo(204);
       promise.complete();
     })), vertx.getOrCreateContext());


### PR DESCRIPTION
This record is added only once.. never replaced..  That means, for example, adding a password will not be removed.