### PR TITLE
Add copycat profile for the Library of Congress

### DIFF
--- a/src/main/resources/reference-data/profiles/library-of-congress.json
+++ b/src/main/resources/reference-data/profiles/library-of-congress.json
@@ -1,0 +1,9 @@
+{
+  "id": "8594713d-4525-4cc7-b138-a07db4692c37",
+  "name": "Library of Congress",
+  "url": "lx2.loc.gov:210/LCDB",
+  "externalIdQueryMap": "@attr 1=9 $identifier",
+  "internalIdEmbedPath": "999ff$i",
+  "externalIdentifierType": "c858e4f2-2b6b-4385-842b-60732ee14abb",
+  "enabled": false
+}


### PR DESCRIPTION
This is initially disabled, since the front-end software doesn't yet
know how to deal with more than one profile being enabled at once.