### PR TITLE
Poll failure: omit internalIdentifier in response MODCPCT-35

### DIFF
--- a/src/main/java/org/folio/copycat/RecordImporter.java
+++ b/src/main/java/org/folio/copycat/RecordImporter.java
@@ -250,27 +250,19 @@ public class RecordImporter {
     });
   }
 
-  Future<List<String>> end() {
-    return end(Collections.emptyList());
-  }
-
   /**
    * end importing.
-   * @param instances existing instances (non-empty for update).
    * @return async result with list of instances.
    */
-  public Future<List<String>> end(List<String> instances) {
+  public Future<List<String>> end() {
     return post(null, true)
-      .compose(x -> {
-        if (!instances.isEmpty()) {
-          return Future.succeededFuture(instances);
-        }
-        return getSourceRecords(1)
+      .compose(x ->
+        getSourceRecords(1)
           .recover(cause -> {
             log.warn("Polling failed and ignored: {}", cause.getMessage(), cause);
-            return Future.succeededFuture(instances);
-          });
-      })
+            return Future.succeededFuture(Collections.emptyList());
+          })
+      )
       .onComplete(x -> client.close());
   }
 }

--- a/src/main/java/org/folio/rest/impl/CopycatImpl.java
+++ b/src/main/java/org/folio/rest/impl/CopycatImpl.java
@@ -133,6 +133,7 @@ public class CopycatImpl implements org.folio.rest.jaxrs.resource.Copycat {
                 log.info("Got instance identifiers: {}", String.join(", ", instances));
                 entity.setInternalIdentifier(instances.get(0));
               } else {
+                log.info("Got no instance identifiers");
                 entity.setInternalIdentifier(null);
               }
               asyncResultHandler.handle(

--- a/src/main/java/org/folio/rest/impl/CopycatImpl.java
+++ b/src/main/java/org/folio/rest/impl/CopycatImpl.java
@@ -29,7 +29,6 @@ import org.folio.rest.persist.PostgresClient;
 import org.marc4j.MarcJsonWriter;
 import org.marc4j.MarcStreamReader;
 import org.marc4j.converter.impl.AnselToUnicode;
-import org.marc4j.marc.Leader;
 
 public class CopycatImpl implements org.folio.rest.jaxrs.resource.Copycat {
   static Errors createErrors(String message) {
@@ -125,7 +124,7 @@ public class CopycatImpl implements org.folio.rest.jaxrs.resource.Copycat {
             RecordImporter importer = new RecordImporter(okapiHeaders, vertxContext);
             return importer.begin(jobProfile)
                 .compose(x -> importer.post(marc))
-                .compose(x -> importer.end(instances));
+                .compose(x -> importer.end());
           });
         })
         .onSuccess(
@@ -133,6 +132,8 @@ public class CopycatImpl implements org.folio.rest.jaxrs.resource.Copycat {
               if (!instances.isEmpty()) {
                 log.info("Got instance identifiers: {}", String.join(", ", instances));
                 entity.setInternalIdentifier(instances.get(0));
+              } else {
+                entity.setInternalIdentifier(null);
               }
               asyncResultHandler.handle(
                   Future.succeededFuture(

--- a/src/test/java/org/folio/copycat/RecordImporterTest.java
+++ b/src/test/java/org/folio/copycat/RecordImporterTest.java
@@ -8,7 +8,6 @@ import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/test/java/org/folio/copycat/RecordImporterTest.java
+++ b/src/test/java/org/folio/copycat/RecordImporterTest.java
@@ -384,9 +384,9 @@ public class RecordImporterTest {
     String jobProfileId = UUID.randomUUID().toString();
     Future<List<String>> future = importer.begin(jobProfileId)
       .compose(x -> importer.post(marc1))
-      .compose(x -> importer.end(Collections.singletonList("9876")));
+      .compose(x -> importer.end());
     future.onComplete(context.succeeding(x -> {
-      assertThat(x).containsExactly("9876");
+      assertThat(x).isEmpty();
       assertThat(mock.getLastJobProfileJobId()).isEqualTo(jobProfileId);
       context.completeNow();
     }));

--- a/src/test/java/org/folio/rest/impl/CopycatTest.java
+++ b/src/test/java/org/folio/rest/impl/CopycatTest.java
@@ -368,6 +368,46 @@ class CopycatTest {
   }
 
   @Test
+  void testImportProfileWithInternalIdentifierPollFailure(Vertx vertx, VertxTestContext context) {
+    Copycat api = new CopycatImpl();
+
+    Map<String, String> headers = new HashMap<>();
+    headers.put(XOkapiHeaders.TENANT, tenant);
+    headers.put(XOkapiHeaders.URL, "http://localhost:" + mockPort);
+    headers.put(XOkapiHeaders.USER_ID, UUID.randomUUID().toString());
+    Context vertxContext = vertx.getOrCreateContext();
+
+    // make poll fail
+    mock.setSourceRecordStorageStatus(404);
+
+    CopyCatProfile copyCatProfile = new CopyCatProfile()
+      .withName("index data")
+      .withUrl(URL_INDEXDATA)
+      .withExternalIdQueryMap("$identifier")
+      .withInternalIdEmbedPath("999ff$i");
+    api.postCopycatProfiles(copyCatProfile, headers, context.succeeding(res1 -> context.verify(() -> {
+      assertThat(res1.getStatus()).isEqualTo(201);
+      CopyCatProfile responseProfile = (CopyCatProfile) res1.getEntity();
+      String targetProfileId = responseProfile.getId();
+      CopyCatImports copyCatImports = new CopyCatImports()
+        .withProfileId(targetProfileId)
+        .withInternalIdentifier("1234")
+        .withExternalIdentifier(EXTERNAL_ID_INDEXDATA); // gets 1 record
+      api.postCopycatImports(copyCatImports, headers, context.succeeding(res -> context.verify(() -> {
+        assertThat(res.getStatus()).isEqualTo(200);
+        CopyCatImports importsResponse = (CopyCatImports) res.getEntity();
+        assertThat(importsResponse.getInternalIdentifier()).isNull(); // poll failed so no internalIdentifier
+        api.deleteCopycatProfilesById(targetProfileId, headers, context.succeeding(res3 -> context.verify(() ->
+          context.completeNow()
+        )), vertxContext);
+      })), vertxContext);
+    })), vertxContext);
+  }
+
+
+
+
+  @Test
   void testImportProfileMissingInternalIdEmbedPath(Vertx vertx, VertxTestContext context) {
     Copycat api = new CopycatImpl();
 


### PR DESCRIPTION
Omit internalIdentifier for both update and import in case of poll failure.