### PR TITLE
Update "source-manager-job-executions" interface version from 2.0 to 3.0

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -74,7 +74,7 @@
   "requires" : [
     {
       "id" : "source-manager-job-executions",
-      "version" : "2.0"
+      "version" : "3.0"
     },
     {
       "id" : "source-manager-records",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -74,7 +74,7 @@
   "requires" : [
     {
       "id" : "source-manager-job-executions",
-      "version" : "3.0"
+      "version" : "2.0 3.0"
     },
     {
       "id" : "source-manager-records",


### PR DESCRIPTION
## Purpose
In the scope of the [PR](https://github.com/folio-org/mod-source-record-manager/pull/530/commits/8089c6aa8e42ca7d63d3c8990128eb1cffabdc18)  the query parameters for `GET /metadata-provider/jobExecutions` endpoint were changed, so 
"source-manager-job-executions" interface version will be increased: from 2.0 to 3.0. It is necessary to update interface dependency

## Approach
* update "source-manager-job-executions" interface dependency to "2.0 3.0"  versions

##