### PR TITLE
[MODCPCT-69]Create an upgrade process for existing Z39.50 target prof…

### DIFF
--- a/src/main/resources/reference-data/profiles/library-of-congress.json
+++ b/src/main/resources/reference-data/profiles/library-of-congress.json
@@ -7,6 +7,8 @@
   "externalIdentifierType": "c858e4f2-2b6b-4385-842b-60732ee14abb",
   "createJobProfileId": "d0ebb7b0-2f0f-11eb-adc1-0242ac120002",
   "updateJobProfileId": "91f9b8d6-d80e-4727-9783-73fb53e3c786",
+  "allowedCreateJobProfileIds": ["d0ebb7b0-2f0f-11eb-adc1-0242ac120002"],
+  "allowedUpdateJobProfileIds": ["91f9b8d6-d80e-4727-9783-73fb53e3c786"],
   "targetOptions": {
     "preferredRecordSyntax": "usmarc"
   },

--- a/src/main/resources/reference-data/profiles/oclc-worldcat.json
+++ b/src/main/resources/reference-data/profiles/oclc-worldcat.json
@@ -7,6 +7,8 @@
   "externalIdentifierType": "439bfbae-75bc-4f74-9fc7-b2a2d47ce3ef",
   "createJobProfileId": "d0ebb7b0-2f0f-11eb-adc1-0242ac120002",
   "updateJobProfileId": "91f9b8d6-d80e-4727-9783-73fb53e3c786",
+  "allowedCreateJobProfileIds": ["d0ebb7b0-2f0f-11eb-adc1-0242ac120002"],
+  "allowedUpdateJobProfileIds": ["91f9b8d6-d80e-4727-9783-73fb53e3c786"],
   "targetOptions": {
     "charset": "utf-8"
   },

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -1,5 +1,11 @@
 {
-  "scripts" : [ ],
+  "scripts" : [
+    {
+    "run": "after",
+    "snippetPath": "update_profile.sql",
+    "fromModuleVersion": "mod-copycat-1.3.2"
+    }
+  ],
   "tables" : [
     {
       "tableName" : "profile",

--- a/src/main/resources/templates/db_scripts/update_profile.sql
+++ b/src/main/resources/templates/db_scripts/update_profile.sql
@@ -1,0 +1,23 @@
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.update_cpct_profile(
+	input_jsonb jsonb)
+    RETURNS jsonb
+    LANGUAGE 'plpgsql'
+    COST 100
+    VOLATILE PARALLEL UNSAFE
+AS $BODY$
+begin
+  IF(input_jsonb::jsonb->'allowedCreateJobProfileIds' IS NOT NULL) THEN
+	  input_jsonb = jsonb_set(input_jsonb,'{allowedCreateJobProfileIds}',jsonb_build_array(input_jsonb::jsonb->'createJobProfileId'));
+	END IF;
+	IF(input_jsonb::jsonb->'allowedUpdateJobProfileIds' IS NOT NULL) THEN
+  	input_jsonb = jsonb_set(input_jsonb,'{allowedUpdateJobProfileIds}',input_jsonb::jsonb->'updateJobProfileId');
+  END IF;
+
+	return input_jsonb;
+end
+$BODY$;
+
+UPDATE ${myuniversity}_${mymodule}.profile
+  SET jsonb=${myuniversity}_${mymodule}.update_cpct_profile(jsonb);
+
+DROP FUNCTION IF EXISTS ${myuniversity}_${mymodule}.update_cpct_profile(input_jsonb jsonb);


### PR DESCRIPTION
https://issues.folio.org/browse/MODCPCT-69
Update library-of-congress.json and  oclc-worldcat.json - reflect the schema changes described in [MODCPCT-71](https://issues.folio.org/browse/MODCPCT-71), set create/update jobprofileId as default and specify them in the list for allowed jobProfiles
Add migration script for existing profiles: reflect the same changes as above
change createJobProfileId --> defaultCreateJobProfileId
change updateJobProfileId --> defaultUpdateJobProfileId
add array for createJobProfileIds 
add array for updateJobProfileIds