### PR TITLE
MODCPCT-83 fix missing log4j impl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>2.17.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
         <version>${vertx.version}</version>


### PR DESCRIPTION
  - would prevent module from starting after upgrade of Vert.x, ref MODCPCT-82.