### PR TITLE
MODCPCT-87 API versions update

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * [MOCCPCT-82](https://issues.folio.org/browse/MOCCPCT-82) Upgrade to Vert.x 4.5.4
 * [MOCCPCT-80](https://issues.folio.org/browse/MOCCPCT-80) Upgrade to RMB 35.2.0
 * [MOCCPCT-81](https://issues.folio.org/browse/MOCCPCT-81) Finalize upgrade to Java 17
+* [MODCPCT-87](https://folio-org.atlassian.net/browse/MODCPCT-87) Update `source-manager-job-executions` to `3.4` and `source-storage-source-records `to `3.5`
 
 ## 1.5.0 2023-10-11
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,12 @@
+## 1.X.X (Unreleased)
+
+* [MODCPCT-87](https://folio-org.atlassian.net/browse/MODCPCT-87) Update `source-manager-job-executions` to `3.4` and `source-storage-source-records `to `3.5`
+
 ## 1.6.0 2024-03-21
 
 * [MOCCPCT-82](https://issues.folio.org/browse/MOCCPCT-82) Upgrade to Vert.x 4.5.4
 * [MOCCPCT-80](https://issues.folio.org/browse/MOCCPCT-80) Upgrade to RMB 35.2.0
 * [MOCCPCT-81](https://issues.folio.org/browse/MOCCPCT-81) Finalize upgrade to Java 17
-* [MODCPCT-87](https://folio-org.atlassian.net/browse/MODCPCT-87) Update `source-manager-job-executions` to `3.4` and `source-storage-source-records `to `3.5`
 
 ## 1.5.0 2023-10-11
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -32,9 +32,9 @@
           "modulePermissions" : [
             "change-manager.jobexecutions.post",
             "change-manager.jobexecutions.get",
-            "change-manager.jobexecutions.put",
+            "change-manager.jobExecutions.jobProfile.item.put",
             "change-manager.records.post",
-            "source-storage.sourceRecords.get"
+            "source-storage.source-records.collection.get"
           ]
         }
       ]

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -31,7 +31,8 @@
           "permissionsRequired": [ "copycat.imports.post" ],
           "modulePermissions" : [
             "change-manager.jobexecutions.post",
-            "change-manager.jobexecutions.get",
+            "change-manager.jobExecutions.item.get",
+            "change-manager.jobExecutions.children.collection.get",
             "change-manager.jobExecutions.jobProfile.item.put",
             "change-manager.records.post",
             "source-storage.source-records.collection.get"

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -75,7 +75,7 @@
   "requires" : [
     {
       "id" : "source-manager-job-executions",
-      "version" : "2.0 3.0 3.4"
+      "version" : "3.4"
     },
     {
       "id" : "source-manager-records",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -74,7 +74,7 @@
   "requires" : [
     {
       "id" : "source-manager-job-executions",
-      "version" : "2.0 3.0"
+      "version" : "2.0 3.0 3.4"
     },
     {
       "id" : "source-manager-records",
@@ -82,7 +82,7 @@
     },
     {
       "id" : "source-storage-source-records",
-      "version" : "3.0"
+      "version" : "3.2"
     }
   ],
   "permissionSets" : [


### PR DESCRIPTION
[MODCPCT-87](https://folio-org.atlassian.net/browse/MODCPCT-87)

<p data-pm-slice="1 1 []">According to the epic <a data-inline-card="" href="https://folio-org.atlassian.net/browse/FOLIO-4044," data-card-data="">https://folio-org.atlassian.net/browse/FOLIO-4044,</a> some permissions have been changed in the source-manager-job-executions v3.4 and source-storage-source-records v3.5</p><p>mod-copycat uses the following outdated permissions:</p><pre><code>"change-manager.jobexecutions.put"
"source-storage.sourceRecords.get" </code></pre>

New permission | API
-- | --
"change-manager.jobExecutions.jobProfile.item.put" | /change-manager/jobExecutions/{id}/jobProfile
"source-storage.source-records.collection.get" | "/source-storage/source-records"

Merge this pull request at the same time when the other modules merge the permission rename pull requests:
* https://github.com/folio-org/mod-source-record-storage/pull/646
* https://github.com/folio-org/mod-source-record-manager/pull/931
