### PR TITLE
FAT-22537 - Ensure FolioLocal service provider definition to fix FolioLoggingContext issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -380,6 +380,7 @@
                     <Multi-Release>true</Multi-Release>
                   </manifestEntries>
                 </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
               <artifactSet />
               <outputFile>${project.build.directory}/${project.artifactId}-fat.jar</outputFile>


### PR DESCRIPTION
## Purpose
ensure the presence of the FolioLocal service provider definition in the module jar and prevent it from being overridden by other module dependencies to apply the fix for OKAPI-1228, which resolves the race condition issue.

## Approach
Concatenate Service Entries with the ServicesResourceTransformer when executing maven-shade-plugin:
https://maven.apache.org/plugins/maven-shade-plugin/examples/resource-transformers.html#ServicesResourceTransformer

## Learning
[FAT-22537](https://issues.folio.org/browse/FAT-22537)